### PR TITLE
Enable vlan-aware-vms support for Ocata

### DIFF
--- a/neutron/files/ocata/neutron-server.conf.Debian
+++ b/neutron/files/ocata/neutron-server.conf.Debian
@@ -46,7 +46,7 @@ core_plugin = neutron_plugin_contrail.plugins.opencontrail.contrail_plugin.Neutr
 
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 
-service_plugins =neutron.services.l3_router.l3_router_plugin.L3RouterPlugin,neutron.services.metering.metering_plugin.MeteringPlugin{%- if server.lbaas is defined -%}
+service_plugins =neutron.services.l3_router.l3_router_plugin.L3RouterPlugin,neutron.services.metering.metering_plugin.MeteringPlugin,trunk{%- if server.lbaas is defined -%}
 ,neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2
 {%- endif -%}
 


### PR DESCRIPTION
This patch enables 'trunk' API (vlan-aware-vms) for ML2 backend
engine starting from Ocata release (the feature itself was
implemented in Newton release but had issues with OVS-DPDK before
Ocata).

This change does not affect users not utilizing 'trunk' API (i.e.
enabling the API has no effect on compute-side agents).