### PR TITLE
Load Interface and Firewall drivers by name

### DIFF
--- a/neutron/files/mitaka/dhcp_agent.ini
+++ b/neutron/files/mitaka/dhcp_agent.ini
@@ -19,7 +19,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs commands will fail with ALARMCLOCK error. (integer value)
 #ovs_vsctl_timeout = 10

--- a/neutron/files/mitaka/l3_agent.ini
+++ b/neutron/files/mitaka/l3_agent.ini
@@ -25,7 +25,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs commands will fail with ALARMCLOCK error. (integer value)
 #ovs_vsctl_timeout = 10

--- a/neutron/files/mitaka/ml2_conf.ini
+++ b/neutron/files/mitaka/ml2_conf.ini
@@ -199,7 +199,7 @@ vxlan_group = 224.0.0.1
 {%- if server.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It should be false when using no security groups or using the

--- a/neutron/files/mitaka/openvswitch_agent.ini
+++ b/neutron/files/mitaka/openvswitch_agent.ini
@@ -246,7 +246,7 @@ datapath_type = netdev
 {%- if neutron.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It should be false when using no security groups or using the

--- a/neutron/files/newton/dhcp_agent.ini
+++ b/neutron/files/newton/dhcp_agent.ini
@@ -19,7 +19,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs commands will fail with ALARMCLOCK error. (integer value)
 #ovs_vsctl_timeout = 10

--- a/neutron/files/newton/l3_agent.ini
+++ b/neutron/files/newton/l3_agent.ini
@@ -25,7 +25,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs commands will fail with ALARMCLOCK error. (integer value)
 #ovs_vsctl_timeout = 10

--- a/neutron/files/newton/ml2_conf.ini
+++ b/neutron/files/newton/ml2_conf.ini
@@ -199,7 +199,7 @@ vxlan_group = 224.0.0.1
 {%- if server.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It should be false when using no security groups or using the

--- a/neutron/files/newton/openvswitch_agent.ini
+++ b/neutron/files/newton/openvswitch_agent.ini
@@ -246,7 +246,7 @@ datapath_type = netdev
 {%- if neutron.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It should be false when using no security groups or using the

--- a/neutron/files/ocata/dhcp_agent.ini
+++ b/neutron/files/ocata/dhcp_agent.ini
@@ -19,7 +19,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs commands will fail with ALARMCLOCK error. (integer value)
 #ovs_vsctl_timeout = 10

--- a/neutron/files/ocata/l3_agent.ini
+++ b/neutron/files/ocata/l3_agent.ini
@@ -20,7 +20,7 @@
 
 # The driver used to manage the virtual interface. (string value)
 #interface_driver = <None>
-interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+interface_driver = openvswitch
 
 # Timeout in seconds for ovs-vsctl commands. If the timeout expires, ovs
 # commands will fail with ALARMCLOCK error. (integer value)

--- a/neutron/files/ocata/ml2_conf.ini
+++ b/neutron/files/ocata/ml2_conf.ini
@@ -252,7 +252,7 @@ vxlan_group = 224.0.0.1
 {%- if server.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It

--- a/neutron/files/ocata/openvswitch_agent.ini
+++ b/neutron/files/ocata/openvswitch_agent.ini
@@ -307,7 +307,7 @@ datapath_type = netdev
 {%- if neutron.dpdk %}
 firewall_driver = openvswitch
 {%- else %}
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = iptables_hybrid
 {%- endif %}
 
 # Controls whether the neutron security group API is enabled in the server. It


### PR DESCRIPTION
Neutron uses stevedore to load these drivers by name, and when that
fails it looks them up by classname.  A change in stevedore in newton
added a warn_on_missing_entrypoint to the NamedExtensionManager with a
default to True.  Neutron does not set this parameter, so by default it
will log a Warning if you load the driver by class name.

By updating the config to load them by the alias, those warnings no
longer happen, and less code needs to execute to find the class.