### PR TITLE
Allow setting some VXLAN paramters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -514,6 +514,22 @@ Sample Linux network configuration for DVR
             use_ovs_ports:
             - float-to-ex
 
+Additonal VXLAN tenant network settings
+---------------------------------------
+
+The default multicast group of 224.0.0.1 only multicasts to a single subnet.
+Allow overriding it to allow larger underlay network topologies.
+
+Neutron Server
+
+.. code-block:: yaml
+
+    neutron:
+      server:
+        vxlan:
+          group: 239.0.0.0/8
+          vni_ranges: "2:65535"
+
 Neutron VLAN tenant networks with Network Nodes
 -----------------------------------------------
 

--- a/neutron/files/mitaka/ml2_conf.ini
+++ b/neutron/files/mitaka/ml2_conf.ini
@@ -180,12 +180,12 @@ network_vlan_ranges = physnet1{%- if server.backend.external_vlan_range is defin
 # Comma-separated list of <vni_min>:<vni_max> tuples enumerating ranges of VXLAN VNI IDs that are available for tenant network allocation
 # (list value)
 #vni_ranges =
-vni_ranges =2:65535
+vni_ranges = {{ server.get('vxlan', {}).vni_ranges|default('2:65535') }}
 
 # Multicast group for VXLAN. When configured, will enable sending all broadcast traffic to this multicast group. When left unconfigured,
 # will disable multicast VXLAN mode. (string value)
 #vxlan_group = <None>
-vxlan_group = 224.0.0.1
+vxlan_group = {{ server.get('vxlan', {}).group|default('224.0.0.1') }}
 
 
 [securitygroup]

--- a/neutron/files/newton/ml2_conf.ini
+++ b/neutron/files/newton/ml2_conf.ini
@@ -180,12 +180,12 @@ network_vlan_ranges = physnet1{%- if server.backend.external_vlan_range is defin
 # Comma-separated list of <vni_min>:<vni_max> tuples enumerating ranges of VXLAN VNI IDs that are available for tenant network allocation
 # (list value)
 #vni_ranges =
-vni_ranges =2:65535
+vni_ranges = {{ server.get('vxlan', {}).vni_ranges|default('2:65535') }}
 
 # Multicast group for VXLAN. When configured, will enable sending all broadcast traffic to this multicast group. When left unconfigured,
 # will disable multicast VXLAN mode. (string value)
 #vxlan_group = <None>
-vxlan_group = 224.0.0.1
+vxlan_group = {{ server.get('vxlan', {}).group|default('224.0.0.1') }}
 
 
 [securitygroup]

--- a/neutron/files/ocata/ml2_conf.ini
+++ b/neutron/files/ocata/ml2_conf.ini
@@ -232,13 +232,13 @@ network_vlan_ranges = physnet1{%- if server.backend.external_vlan_range is defin
 # Comma-separated list of <vni_min>:<vni_max> tuples enumerating ranges of
 # VXLAN VNI IDs that are available for tenant network allocation (list value)
 #vni_ranges =
-vni_ranges =2:65535
+vni_ranges = {{ server.get('vxlan', {}).vni_ranges|default('2:65535') }}
 
 # Multicast group for VXLAN. When configured, will enable sending all broadcast
 # traffic to this multicast group. When left unconfigured, will disable
 # multicast VXLAN mode. (string value)
 #vxlan_group = <None>
-vxlan_group = 224.0.0.1
+vxlan_group = {{ server.get('vxlan', {}).group|default('224.0.0.1') }}
 
 
 [securitygroup]


### PR DESCRIPTION
Allow setting the multicast group and the VNI range that will be used
when using the ML2 plugin.