### PR TITLE
Remove deprecated rpc_backend setting on newton and ocata.

### DIFF
--- a/neutron/files/newton/neutron-generic.conf.Debian
+++ b/neutron/files/newton/neutron-generic.conf.Debian
@@ -537,7 +537,6 @@ transport_url = rabbit://{{ neutron.message_queue.user }}:{{ neutron.message_que
 # The messaging driver to use, defaults to rabbit. Other drivers include amqp
 # and zmq. (string value)
 #rpc_backend = rabbit
-rpc_backend = rabbit
 
 # The default exchange under which topics are scoped. May be overridden by an
 # exchange name specified in the transport_url option. (string value)

--- a/neutron/files/newton/neutron-generic.conf.Debian
+++ b/neutron/files/newton/neutron-generic.conf.Debian
@@ -1315,7 +1315,6 @@ rabbit_retry_backoff = 2
 # count). (integer value)
 # Deprecated group/name - [DEFAULT]/rabbit_max_retries
 #rabbit_max_retries = 0
-rabbit_max_retries = 0
 
 # Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
 # option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring

--- a/neutron/files/newton/neutron-server.conf.Debian
+++ b/neutron/files/newton/neutron-server.conf.Debian
@@ -1397,7 +1397,6 @@ rabbit_retry_backoff = 2
 # count). (integer value)
 # Deprecated group/name - [DEFAULT]/rabbit_max_retries
 #rabbit_max_retries = 0
-rabbit_max_retries = 0
 
 # Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
 # option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring

--- a/neutron/files/newton/neutron-server.conf.Debian
+++ b/neutron/files/newton/neutron-server.conf.Debian
@@ -547,12 +547,6 @@ rpc_response_timeout=60
 # not set, we fall back to the rpc_backend option and driver specific
 # configuration. (string value)
 #transport_url = <None>
-
-# The messaging driver to use, defaults to rabbit. Other drivers include amqp
-# and zmq. (string value)
-#rpc_backend = rabbit
-rpc_backend = rabbit
-
 {%- if server.message_queue.members is defined %}
 transport_url = rabbit://{% for member in server.message_queue.members -%}
                              {{ server.message_queue.user }}:{{ server.message_queue.password }}@{{ member.host }}:{{ member.get('port', 5672) }}
@@ -562,6 +556,11 @@ transport_url = rabbit://{% for member in server.message_queue.members -%}
 {%- else %}
 transport_url = rabbit://{{ server.message_queue.user }}:{{ server.message_queue.password }}@{{ server.message_queue.host }}:{{ server.message_queue.port }}/{{ server.message_queue.virtual_host }}
 {%- endif %}
+
+# The messaging driver to use, defaults to rabbit. Other drivers include amqp
+# and zmq. (string value)
+#rpc_backend = rabbit
+
 
 # The default exchange under which topics are scoped. May be overridden by an
 # exchange name specified in the transport_url option. (string value)

--- a/neutron/files/ocata/neutron-generic.conf.Debian
+++ b/neutron/files/ocata/neutron-generic.conf.Debian
@@ -1645,7 +1645,6 @@ rabbit_retry_backoff = 2
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #rabbit_max_retries = 0
-rabbit_max_retries = 0
 
 # Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
 # option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring

--- a/neutron/files/ocata/neutron-generic.conf.Debian
+++ b/neutron/files/ocata/neutron-generic.conf.Debian
@@ -605,7 +605,6 @@ transport_url = rabbit://{{ neutron.message_queue.user }}:{{ neutron.message_que
 # Its value may be silently ignored in the future.
 # Reason: Replaced by [DEFAULT]/transport_url
 #rpc_backend = rabbit
-rpc_backend = rabbit
 
 # The default exchange under which topics are scoped. May be overridden by an
 # exchange name specified in the transport_url option. (string value)

--- a/neutron/files/ocata/neutron-server.conf.Debian
+++ b/neutron/files/ocata/neutron-server.conf.Debian
@@ -1720,7 +1720,6 @@ rabbit_retry_backoff = 2
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #rabbit_max_retries = 0
-rabbit_max_retries = 0
 
 # Try to use HA queues in RabbitMQ (x-ha-policy: all). If you change this
 # option, you must wipe the RabbitMQ database. In RabbitMQ 3.0, queue mirroring

--- a/neutron/files/ocata/neutron-server.conf.Debian
+++ b/neutron/files/ocata/neutron-server.conf.Debian
@@ -624,7 +624,6 @@ transport_url = rabbit://{{ server.message_queue.user }}:{{ server.message_queue
 # Its value may be silently ignored in the future.
 # Reason: Replaced by [DEFAULT]/transport_url
 #rpc_backend = rabbit
-rpc_backend = rabbit
 
 # The default exchange under which topics are scoped. May be overridden by an
 # exchange name specified in the transport_url option. (string value)


### PR DESCRIPTION
This setting was deprecated for removal in newton, replaced by
transport_url.  These configurations are also setting transport_url, so
the option is ignored.

This removes a warning issued on service startup:

```
WARNING oslo_config.cfg [-] Option "rpc_backend" from group "DEFAULT" is deprecated for removal.  Its value may be silently ignored in the future.
```