### PR TITLE
Remove deprecated option external_network_bridge

### DIFF
--- a/neutron/files/newton/l3_agent.ini
+++ b/neutron/files/newton/l3_agent.ini
@@ -90,10 +90,12 @@ metadata_port = 8775
 # be used. (string value)
 #external_ingress_mark = 0x2
 
-# Name of bridge used for external network traffic. This should be set to an empty value for the Linux Bridge. When this parameter is set,
-# each L3 agent can be associated with no more than one external network. (string value)
-#external_network_bridge = br-ex
-external_network_bridge = 
+# DEPRECATED: Name of bridge used for external network traffic. When this parameter is set, the L3 agent will plug an interface directly
+# into an external bridge which will not allow any wiring by the L2 agent. Using this will result in incorrect port statuses. This option is
+# deprecated and will be removed in Ocata. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#external_network_bridge =
 
 # Seconds between running periodic tasks (integer value)
 #periodic_interval = 40

--- a/neutron/files/ocata/l3_agent.ini
+++ b/neutron/files/ocata/l3_agent.ini
@@ -106,7 +106,6 @@ metadata_port = 8775
 # This option is deprecated for removal.
 # Its value may be silently ignored in the future.
 #external_network_bridge =
-external_network_bridge = 
 
 # Seconds between running periodic tasks. (integer value)
 #periodic_interval = 40


### PR DESCRIPTION
This option was changed to default to "" in newton, and marked as
deprecated for removal. Since this isn't configurable, leaving it to
default to "" will avoid warnings on service startup.

Updated the Help text for this setting on newton to match that of a
newton release version of neutron-l3-agent.