### PR TITLE
Define a default cache for neutron.control.cluster

### DIFF
--- a/metadata/service/control/cluster.yml
+++ b/metadata/service/control/cluster.yml
@@ -42,3 +42,12 @@ parameters:
         user: nova
         password: ${_param:keystone_nova_password}
         tenant: service
+      cache:
+        engine: memcached
+        members:
+        - host: ${_param:cluster_node01_address}
+          port: 11211
+        - host: ${_param:cluster_node02_address}
+          port: 11211
+        - host: ${_param:cluster_node03_address}
+          port: 11211


### PR DESCRIPTION
This follows the patern of other formulas like nova and glance which
define this default memcached cache engine.  This setting is already in
use by the keystone_authtoken/memcached_servers option, so configuring a
default will configure that cache.