### PR TITLE
Add support for LBaaSv2 from contrail - update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,19 @@ Enable CORS parameters
           max_age: 86400
 
 
+If you want to enable contrail LBaaSv2, then configure pillar like this:
+
+.. code-block:: yaml
+
+  neutron:
+    server:
+      lbaas:
+        enabled: true
+        providers:
+          Opencontrail:
+            engine: contrail-lbaasv2
+
+
 Neutron VXLAN tenant networks with Network nodes
 ------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ If you want to enable contrail LBaaSv2, then configure pillar like this:
       lbaas:
         enabled: true
         providers:
-          Opencontrail:
+          opencontrail:
             engine: contrail-lbaasv2
 
 

--- a/neutron/files/mitaka/neutron-server.conf.Debian
+++ b/neutron/files/mitaka/neutron-server.conf.Debian
@@ -839,6 +839,7 @@ admin_tenant_name={{ server.backend.tenant }}
 auth_region={{ server.identity.region }}
 auth_protocol=http
 revocation_cache_time = 10
+
 {% if server.backend.engine == "contrail" %}
 # LBaaS contrail neutron plugin for versions 3.x expects auth_type to be 
 # 'keystone' or 'noauth'
@@ -1673,6 +1674,13 @@ user={{ lbaas.controller_user }}
 password={{ lbaas.controller_password }}
 cloud={{ lbaas.controller_cloud_name }}
 {%- endif -%}
+
+{%- if lbaas.engine == 'contrail-lbaasv2' -%}
+
+service_provider = LOADBALANCERV2:Opencontrail:neutron_plugin_contrail.plugins.opencontrail.loadbalancer.driver.OpencontrailLoadbalancerDriver:default
+
+{% include "neutron/files/"+server.version+"/ContrailPlugin.ini" %}
+{% endif %}
 
 {%- endfor -%}
 


### PR DESCRIPTION
This is a fix for #7 

For lbaasv2, the service_provider part was missing