### PR TITLE
pike/neutron.server.conf.Debian: Fix undefined var

### DIFF
--- a/neutron/files/pike/neutron-server.conf.Debian
+++ b/neutron/files/pike/neutron-server.conf.Debian
@@ -717,7 +717,7 @@ root_helper = sudo /usr/bin/neutron-rootwrap /etc/neutron/rootwrap.conf
 # needs to execute commands in Dom0 in the hypervisor of XenServer, this item
 # should be set to 'xenapi_root_helper', so that it will keep a XenAPI session
 # to pass commands to Dom0. (string value)
-{%- if neutron.root_helper_daemon|default(True) %}
+{%- if server.root_helper_daemon|default(True) %}
 root_helper_daemon = sudo neutron-rootwrap-daemon /etc/neutron/rootwrap.conf
 {%- else %}
 #root_helper_daemon = <None>


### PR DESCRIPTION
Fixes include name mismatch (copy-paste error most likely).
Although templates are quite similar, one imports neutron.server as neutron, while the other does not use an alias for the include.

[1] https://build.opnfv.org/ci/job/fuel-verify-deploy-virtual-master/1756/console