### PR TITLE
Set correct salt query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -917,6 +917,7 @@ Compute node:
         external_access: false
         backend:
           engine: ovn
+          ovn_encap_type: geneve
           ovsdb_connection: tcp:127.0.0.1:6640
         metadata:
           enabled: true

--- a/metadata/service/compute/ovn/single.yml
+++ b/metadata/service/compute/ovn/single.yml
@@ -18,6 +18,7 @@ parameters:
       external_bridge: ${_param:ovn_external_bridge}
       backend:
         engine: ovn
+        ovn_encap_type: geneve
         ovsdb_connection: tcp:127.0.0.1:6640
       metadata:
         enabled: true

--- a/neutron/compute.sls
+++ b/neutron/compute.sls
@@ -124,30 +124,25 @@ ovn_packages:
 
 remote_ovsdb_access:
   cmd.run:
-  - name: "ovs-vsctl set open .
-  external-ids:ovn-remote=tcp:{{ compute.controller_vip }}:6642"
+  - name: "ovs-vsctl set open . external-ids:ovn-remote=tcp:{{ compute.controller_vip }}:6642"
 
 enable_overlays:
   cmd.run:
-  - name: "ovs-vsctl set open .
-  external-ids:ovn-encap-type={{ compute.backend.ovn_encap_type }}"
+  - name: "ovs-vsctl set open . external-ids:ovn-encap-type={{ compute.backend.ovn_encap_type }}"
 
 configure_local_endpoint:
   cmd.run:
-  - name: "ovs-vsctl set open .
-  external-ids:ovn-encap-ip={{ compute.local_ip }}"
+  - name: "ovs-vsctl set open . external-ids:ovn-encap-ip={{ compute.local_ip }}"
 
       {%- if compute.get('external_access', True) %}
 
 set_bridge_external_id:
   cmd.run:
-  - name: "ovs-vsctl --no-wait br-set-external-id
-   {{ compute.external_bridge }} bridge-id {{ compute.external_bridge }}"
+  - name: "ovs-vsctl --no-wait br-set-external-id {{ compute.external_bridge }} bridge-id {{ compute.external_bridge }}"
 
 set_bridge_mapping:
   cmd.run:
-  - name: "ovs-vsctl set open .
-   external-ids:ovn-bridge-mappings=physnet1:{{ compute.external_bridge }}"
+  - name: "ovs-vsctl set open . external-ids:ovn-bridge-mappings=physnet1:{{ compute.external_bridge }}"
 
       {%- endif %}
 

--- a/neutron/compute.sls
+++ b/neutron/compute.sls
@@ -129,7 +129,8 @@ remote_ovsdb_access:
 
 enable_overlays:
   cmd.run:
-  - name: "ovs-vsctl set open . external-ids:ovn-encap-type=geneve,vxlan"
+  - name: "ovs-vsctl set open .
+  external-ids:ovn-encap-type={{ compute.backend.ovn_encap_type }}"
 
 configure_local_endpoint:
   cmd.run:

--- a/neutron/map.jinja
+++ b/neutron/map.jinja
@@ -6,7 +6,7 @@
     'enabled': false }
 %}
 
-{%- if grains.os_family == "Debian" %}
+{%- if salt['grains.get']('os_family') == 'Debian' %}
 {%- set compute_pkgs_ovn = ['ovn-common', 'ovn-host'] %}
 {%- if pillar.neutron.compute is defined and pillar.neutron.compute.metadata is defined %}
 {%- do compute_pkgs_ovn.extend(['neutron-common', 'python-networking-ovn', 'haproxy']) %}

--- a/tests/pillar/compute_ovn.sls
+++ b/tests/pillar/compute_ovn.sls
@@ -7,6 +7,7 @@ neutron:
     external_access: false
     backend:
       engine: ovn
+      ovn_encap_type: geneve
       ovsdb_connection: tcp:127.0.0.1:6640
     metadata:
       enabled: true


### PR DESCRIPTION
In newer version of salt >= 2018.3 construction {%- if grains.os_family == "Debian" %} not working. 
Changed to standard {%- if salt['grains.get']('os_family') == 'Debian' %} in map. jinja